### PR TITLE
Revive dead links in "Roles and Responsibilities"

### DIFF
--- a/docs/contribute/roles-responsibilities.md
+++ b/docs/contribute/roles-responsibilities.md
@@ -8,7 +8,7 @@ title: 1Hive Roles and Responsibilities
 
 Anyone can contribute to the 1Hive DAO by engaging with the community on Keybase, creating new Issues on GitHub, working on open Issues on GitHub. This does not require anyone's permission. Reviewers can assign tasks to the contributor's GitHub account and pay out HONEY bounties to the worker's Ethereum address upon successful completion. This does not require any permissions within the 1Hive DAO.
 
-The roles and responsibilities of curators can be found [here](https://1hive.org/docs/contribute/projects-tasks.html#expectations-of-workers).
+The roles and responsibilities of curators can be found [here](https://1hive.org/contribute/projects-tasks#expectations-of-workers).
 
 If a Worker earns (or purchases) HONEY, they will have HONEY voting rights within the [1Hive DAO](https://rinkeby.aragon.org/#/0xe520428C232F6Da6f694b121181f907931fD2211). This includes the following permissions in the HONEY token Voting app:
 - Create new votes
@@ -17,7 +17,7 @@ If a Worker earns (or purchases) HONEY, they will have HONEY voting rights withi
 
 ## BEEs
 
-The roles and responsibilities of BEEs can be found [here](https://1hive.org/docs/contribute/membership.html#membership-guidelines). Current BEEs are:
+The roles and responsibilities of BEEs can be found [here](https://1hive.org/contribute/membership#membership-guidelines). Current BEEs are:
 - [Luke Duncan](https://github.com/lkngtn) - @lkngtn on Keybase
 - [burrrata](https://github.com/burrrata) - @burrrata on Keybase
 - [Gabriel Garcia](https://github.com/0xGabi) - @goliat on Keybase
@@ -33,7 +33,7 @@ The roles and responsibilities of BEEs can be found [here](https://1hive.org/doc
 
 ## HONEY Holders
 
-The roles and responsibilities of HONEY Holders can be found [here](https://1hive.org/docs/contribute/membership.html#why-honey).
+The roles and responsibilities of HONEY Holders can be found [here](https://1hive.org/contribute/membership#why-honey).
 
 Current HONEY Holders can be found on the 1Hive DAO in the [token manager](https://rinkeby.aragon.org/#/0xe520428C232F6Da6f694b121181f907931fD2211/0xda552be756aeb99df8d7ded3d853e1d57efa2442) app.
 
@@ -45,7 +45,7 @@ Current HONEY Holders can be found on the 1Hive DAO in the [token manager](https
 
 ## Curators
 
-The roles and responsibilities of Curators can be found [here](https://1hive.org/docs/contribute/projects-tasks.html#expectations-of-curators). Current Curators are:
+The roles and responsibilities of Curators can be found [here](https://1hive.org/contribute/projects-tasks#expectations-of-curators). Current Curators are:
 - [Luke Duncan](https://github.com/lkngtn) - @lkngtn on Keybase
 - [burrrata](https://github.com/burrrata) - @burrrata on Keybase
 
@@ -59,7 +59,7 @@ The roles and responsibilities of Curators can be found [here](https://1hive.org
 
 ## Reviewers
 
-The roles and responsibilities of Reviewers can be found [here](https://1hive.org/docs/contribute/projects-tasks.html#expectations-of-curators). Current Reviewers are:
+The roles and responsibilities of Reviewers can be found [here](https://1hive.org/contribute/projects-tasks#expectations-of-curators). Current Reviewers are:
 - [Luke Duncan](https://github.com/lkngtn) - @lkngtn on Keybase
 - [burrrata](https://github.com/burrrata) - @burrrata on Keybase
 


### PR DESCRIPTION
Fixes all the dead links on the "Roles and Responsibilities" page (and closes #48).