### PR TITLE
Fix broken "learn more" link

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -108,7 +108,7 @@ class Index extends React.Component {
             </p>
             <a
               className="learnmore"
-              href="/docs/contribute/welcome">
+              href="/contribute/welcome">
               Learn more
             </a>
           </div>


### PR DESCRIPTION
The learn more link under "Contributing to 1Hive" links to an old page that has been moved